### PR TITLE
marco/read-through-updates

### DIFF
--- a/EIPS/eip-7160.md
+++ b/EIPS/eip-7160.md
@@ -17,41 +17,76 @@ This EIP proposes an extension to the [ERC-721](./eip-721.md) standard to suppor
 
 ## Motivation
 
-The current [ERC-721](./eip-721.md) standard allows for a single metadata URI per token. However, there are use cases where multiple metadata URIs are desirable, such as when a token represents a collection of (cycling) assets with individual metadata, historic token metadata, collaborative and multi-artist tokens, evolving tokens. This extension enables such use cases by introducing the concept of multi-metadata support.
+The current [ERC-721](./eip-721.md) standard allows for a single metadata URI per token with the `ERC721Metadata` implementation. However, there are use cases where multiple metadata URIs are desirable. Some example use cases are listed below:
+- A token represents a collection of (cycling) assets with individual metadata
+- An on-chain history of revisions to token metadata
+- Appending metadata with different aspect ratios so that it can be displayed properly on all screens
+- Dynamic & evolving metadata
+- Collaborative and multi-artist tokens
 
-The primary reason for having a multi-metadata standard versus using the existing `tokenURI` method with some token-specific functions to change the active URI is that dapps and marketplaces don't have a mechanism to infer and display all the token URIs. Furthermore the non-pinned URIs might be equally important: imagine a colaborative token with multiple artworks per token. Multi-metadata tokens can be displayed in a carousel, gallery, list, etc.
+This extension enables such use cases by introducing the concept of multi-metadata support.
+
+The primary reason for having a multi-metadata standard in addition to the existing `ERC721Metadata` standard is that dapps and marketplaces don't have a mechanism to infer and display all the token URIs. Giving a standard way for marketplaces to offer collectors a way to pin/unpin one of the metadata choices also enables quick & easy adoption of this functionality. These features 
 
 ## Specification
 
-The `IERC721MultiMetadata` interface:
+The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be interpreted as described in RFC 2119.
+
+**The multi-metadata extension is OPTIONAL for EIP-721 contracts and it is RECOMMENDED to be used in conjuction with the `EIP-4906` standard if implemented**
 
 ```solidity
-interface IERC721MultiMetadata /* is IERC721 */ {
+/// @title EIP-721 Multi-Metdata Extension
+/// @dev See https://eips.ethereum.org/EIPS/eip-721
+///  Note: the ERC-165 identifier for this interface is 0x06e1bc5b.
+interface IERC721MultiMetadata /* is IERC721Metadata */ {
+  /// @dev This event emits when a token uri is pinned and is 
+  ///  useful for indexing purposes.
   event TokenUriPinned(uint256 indexed tokenId, uint256 indexed index, address indexed sender);
+
+  /// @dev This event emits when a token uri is unpinned and is 
+  ///  useful for indexing purposes.
   event TokenUriUnpinned(uint256 indexed tokenId, address indexed sender);
 
+  /// @notice Get all token uris associated with a particular token
+  /// @dev If a token uri is pinned, the index returned should be the index in the string array
+  /// @param tokenId The identifier for the nft
+  /// @return index An unisgned integer that specifies which uri is pinned for a token (or the default uri if unpinned)
+  /// @return uris A string array of all uris associated with a token
   function tokenURIs(uint256 tokenId) external view returns (uint256 index, string[] memory uris);
+
+  /// @notice Pin a specific token uri for a particular token
+  /// @param tokenId The identifier of the nft
+  /// @param index The index in the string array returned from the `tokenURIs` function that should be pinned for the token
   function pinTokenURI(uint256 tokenId, uint256 index) external;
+
+  /// @notice Unpin metadata for a particular token
+  /// @dev This should reset the token to the default uri
+  /// @param tokenId The identifier of the nft
   function unpinTokenURI(uint256 tokenId) external;
+
+  /// @notice Check on-chain if a token id has a pinned uri or not
+  /// @dev Useful for on-chain mechanics
+  /// @param tokenId The identifier of the nft
+  /// @return pinned A bool specifying if a token has metadata pinned or not
   function hasPinnedTokenURI(uint256 tokenId) external view returns (bool pinned);
 }
 ```
 
-The `tokenURIs` function returns a tuple containing the pinned URI index and a list of all metadata URIs associated with the specified token.
+The `TokenUriPinned` event MUST be emitted when pinning a token uri with the `pinTokenUri` function.
 
-`tokenURIs` is the core method of a multi-metadata token and the additional methods and events are meant to provide a standard interface to dapps to perform pinning and unpinning actions.
+The `TokenUriUnpinned` event MUST be emitted when unpinning a token uri with the `unpinTokenUri` function.
 
-The `pinTokenURI` function allows the contract owner to designate a specific metadata URI as the pinned URI for a token.
+The `tokenURI` function defined in the ERC-721 Metadata standard MUST return the pinned URI when a token has a pinned uri. The `tokenURI` fucntion MUST return a default uri when a token has an unpinned uri. Which uri is returned when unpinned is up to the developer and is not specified in this standard. This ensures backwards compatibility with existing contracts and applications that rely on the single metadata URI.
 
-The `unpinTokenURI` function allows the contract owner to remove the pin on a specific URI index.
+The `supportsInterface` method MUST return true when called with 0x06e1bc5b.
 
-The `tokenURI` function defined in the ERC-721 standard must return the pinned URI or the last URI in the list returned by `tokenURIs` when there is not pinned URI. This ensures backwards compatibility with existing contracts and applications that rely on the single metadata URI.
-
-When adding new URIs it is highly encouraged to implement [ERC-4906](./eip-4906.md) and emit a `MetadataUpdate` event.
+Implementing functionality to add uris to a token MUST be implemented separately from this standard. A `MetadataUpdate` or `BatchMetadataUpdate` event SHOULD be emitted when adding a uri to a token.
 
 See the [Implementation](#reference-implementation) section for an example.
 
 ## Rationale
+
+The `tokenURIs` function MUST revert if the token does not exist.
 
 The `tokenURIs` function returns both the pinned URI index and the list of all metadata URIs to provide flexibility in accessing the metadata.
 
@@ -63,7 +98,7 @@ When unpinned, it is recommended to return the last URI for the token. However t
 
 ## Backwards Compatibility
 
-This extension is designed to be backward compatible with existing [ERC-721](./eip-721.md) contracts. The implementation of the `tokenURI` method must either return the last URI in the list returned by tokenURIs or the pinned URI.
+This extension is designed to be backward compatible with existing [ERC-721](./eip-721.md) contracts. The implementation of the `tokenURI` method must either return the pinned token uri (if pinned) or some default uri (if unpinned).
 
 ## Reference Implementation
 
@@ -74,26 +109,27 @@ An open-source reference implementation of the `IERC721MultiMetadata` interface 
 
 pragma solidity ^0.8.19;
 
-import "./token/ERC721/ERC721.sol";
-import "./access/Ownable.sol";
-import "./interfaces/IERC4906.sol";
-import "./IERC721MultiMetadata.sol";
+import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {IERC4906} from "@openzeppelin/contracts/interfaces/IERC4906.sol";
+import {IERC721MultiMetadata} from "./IERC721MultiMetadata.sol";
 
-contract MultiMetadata is Ownable, ERC721, IERC721MultiMetadata, IERC4906 {
-  mapping(uint256 => string[]) _tokenURIs;
-  mapping(uint256 => uint256) _pinnedURIIndices;
-  mapping(uint256 => bool) _hasPinnedTokenURI;
+contract MultiMetadata is ERC721, Ownable, IERC721MultiMetadata, IERC4906 {
+  mapping(uint256 => string[]) private _tokenURIs;
+  mapping(uint256 => uint256) private _pinnedURIIndices;
+  mapping(uint256 => bool) private _hasPinnedTokenURI;
 
-  constructor(string memory name_, string memory symbol_) ERC721(name_, symbol_) {
+  constructor(string memory _name, string memory _symbol) ERC721(_name, _symbol) Ownable() {
     _mint(msg.sender, 1);
   }
 
-  // Returns the pinned URI index or the last token URI index (length - 1).
+  // @notice Returns the pinned URI index or the last token URI index (length - 1).
   function _getTokenURIIndex(uint256 tokenId) internal view returns (uint256) {
     return _hasPinnedTokenURI[tokenId] ? _pinnedURIIndices[tokenId] : _tokenURIs[tokenId].length - 1;
   }
 
-  // Implementation of ERC721.tokenURI for backwards compatibility.
+  // @notice Implementation of ERC721.tokenURI for backwards compatibility.
+  // @inheritdoc ERC721.tokenURI
   function tokenURI(uint256 tokenId) public view virtual override returns (string memory) {
     _requireMinted(tokenId);
 
@@ -106,13 +142,13 @@ contract MultiMetadata is Ownable, ERC721, IERC721MultiMetadata, IERC4906 {
     return uri;
   }
 
-  // Retrieves the pinned URI index and the list of all metadata URIs associated with the specified token.
+  /// @inheritdoc IERC721MultiMetadata.tokenURIs
   function tokenURIs(uint256 tokenId) external view returns (uint256 index, string[] memory uris) {
     _requireMinted(tokenId);
     return (_getTokenURIIndex(tokenId), _tokenURIs[tokenId]);
   }
 
-  // Sets a specific metadata URI as the pinned URI for a token.
+  /// @inheritdoc IERC721MultiMetadata.pinTokenURI
   function pinTokenURI(uint256 tokenId, uint256 index) external {
     require(msg.sender == ownerOf(tokenId), "Unauthorized");
     _pinnedURIIndices[tokenId] = index;
@@ -120,7 +156,7 @@ contract MultiMetadata is Ownable, ERC721, IERC721MultiMetadata, IERC4906 {
     emit TokenUriPinned(tokenId, index, msg.sender);
   }
 
-  // Unsets the pinned URI for a token.
+  /// @inheritdoc IERC721MultiMetadata.unpinTokenURI
   function unpinTokenURI(uint256 tokenId) external {
     require(msg.sender == ownerOf(tokenId), "Unauthorized");
     _pinnedURIIndices[tokenId] = 0;
@@ -128,13 +164,12 @@ contract MultiMetadata is Ownable, ERC721, IERC721MultiMetadata, IERC4906 {
     emit TokenUriUnpinned(tokenId, msg.sender);
   }
 
-  // Checks if a token has a pinned URI.
+  /// @inheritdoc IERC721MultiMetadata.hasPinnedTokenURI
   function hasPinnedTokenURI(uint256 tokenId) external view returns (bool isPinned) {
-    require(msg.sender == ownerOf(tokenId), "Unauthorized");
     return _hasPinnedTokenURI[tokenId];
   }
 
-  // Sets a specific metadata URI for a token at the given index.
+  /// @notice Sets a specific metadata URI for a token at the given index.
   function setUri(uint256 tokenId, uint256 index, string calldata uri) external onlyOwner {
     if (_tokenURIs[tokenId].length > index) {
       _tokenURIs[tokenId][index] = uri;
@@ -158,7 +193,9 @@ contract MultiMetadata is Ownable, ERC721, IERC721MultiMetadata, IERC4906 {
 
 ## Security Considerations
 
-This extension does not poses new security risks outside of those that might arise from existing token URI handling practices.
+Care should be taken when specifying access controls for state changing events, such as those that allow uris to be added to tokens
+and those specified in this standard: the `pinTokenUri` and `unpinTokenUri` functions. This is up to the developers to specify
+as each application may have different requirements to allow for pinning and unpinning. 
 
 ## Copyright
 


### PR DESCRIPTION
Updates that I can remember and we can discuss
- added natspec to the interface and reference implementation
- made use of keywords from RFC 2119
- listed out potential use cases rather than in one sentence
- general updates to wording
- removed reference that the default method of handling unpinned uris is defined as the latest uri as that is highly dependent on the application
- added interface id as is
- improved rationale section
- removed token ownership check in the reference implementation from `hasPinnedTokenUri` as that is a view function and doesn't need that check
- added imports from openzeppelin in the reference implementation
- change linearzation of parent contracts in reference implementation
- added Ownable constructor explicitly in the reference implementation
- updated security considerations as there are some to be aware of but nothing out of the ordinary